### PR TITLE
Added media controls to demo video

### DIFF
--- a/src/components/Demo.tsx
+++ b/src/components/Demo.tsx
@@ -33,6 +33,7 @@ const Demo = () => {
               autoPlay
               playsInline
               muted
+              controls
               className="w-full h-full object-cover"
               src="/product-demo.mp4"
             >


### PR DESCRIPTION
### The Issue:

The current production version of the website lacks media controls for the demo video. Because autoplay requires the video to start muted, users are forced to watch it without sound and without any clear way to unmute it.

### The Solution:

Added the `controls` attribute to enable standard media controls.